### PR TITLE
Fixing line number placement for inline renderer

### DIFF
--- a/lib/Diff/Renderer/Html/Inline.php
+++ b/lib/Diff/Renderer/Html/Inline.php
@@ -128,8 +128,8 @@ class Diff_Renderer_Html_Inline extends Diff_Renderer_Html_Array
 					foreach($change['changed']['lines'] as $no => $line) {
 						$toLine = $change['changed']['offset'] + $no + 1;
 						$html .= '<tr>';
-						$html .= '<th>'.$toLine.'</th>';
 						$html .= '<th>&nbsp;</th>';
+						$html .= '<th>'.$toLine.'</th>';
 						$html .= '<td class="Right"><span>'.$line.'</span></td>';
 						$html .= '</tr>';
 					}


### PR DESCRIPTION
Hey, look, I'm a contributor!

#### Summary: ####
'new' line numbers have been displayed in the 'old' column, which makes it confusing.Put them in the 'new' column so things look right.