### PR TITLE
Removing superfluous closing spans

### DIFF
--- a/lib/Diff/Renderer/Html/SideBySide.php
+++ b/lib/Diff/Renderer/Html/SideBySide.php
@@ -83,9 +83,9 @@ class Diff_Renderer_Html_SideBySide extends Diff_Renderer_Html_Array
 						$toLine = $change['changed']['offset'] + $no + 1;
 						$html .= '<tr>';
 						$html .= '<th>'.$fromLine.'</th>';
-						$html .= '<td class="Left"><span>'.$line.'</span>&nbsp;</span></td>';
+						$html .= '<td class="Left"><span>'.$line.'</span>&nbsp;</td>';
 						$html .= '<th>'.$toLine.'</th>';
-						$html .= '<td class="Right"><span>'.$line.'</span>&nbsp;</span></td>';
+						$html .= '<td class="Right"><span>'.$line.'</span>&nbsp;</td>';
 						$html .= '</tr>';
 					}
 				}


### PR DESCRIPTION
#### Summary ####
We've been closing them twice. Don't do that anymore.

#### Test Plan ####
Opened up the source in Firefox before and after. No invalid Markup is being highlighted anymore :)
