### PR TITLE
Fixed multi-byte support for HTML output

### DIFF
--- a/lib/Diff/Renderer/Html/Array.php
+++ b/lib/Diff/Renderer/Html/Array.php
@@ -5,10 +5,10 @@
  * PHP version 5
  *
  * Copyright (c) 2009 Chris Boulton <chris.boulton@interspire.com>
- * 
+ *
  * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
+ *
+ * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *
  *  - Redistributions of source code must retain the above copyright notice,
@@ -16,20 +16,20 @@
  *  - Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- *  - Neither the name of the Chris Boulton nor the names of its contributors 
- *    may be used to endorse or promote products derived from this software 
+ *  - Neither the name of the Chris Boulton nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
  *    without specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
  * @package DiffLib
@@ -82,12 +82,18 @@ class Diff_Renderer_Html_Array extends Diff_Renderer_Abstract
 
 						list($start, $end) = $this->getChangeExtent($fromLine, $toLine);
 						if($start != 0 || $end != 0) {
-							$last = $end + strlen($fromLine);
-							$fromLine = substr_replace($fromLine, "\0", $start, 0);
-							$fromLine = substr_replace($fromLine, "\1", $last + 1, 0);
-							$last = $end + strlen($toLine);
-							$toLine = substr_replace($toLine, "\0", $start, 0);
-							$toLine = substr_replace($toLine, "\1", $last + 1, 0);
+                            $realEnd = mb_strlen($fromLine) + $end;
+                            $fromLine = mb_substr($fromLine, 0, $start)
+                                . "\0"
+                                . mb_substr($fromLine, $start, $realEnd - $start)
+                                . "\1"
+                                . mb_substr($fromLine, $realEnd);
+                            $realEnd = mb_strlen($toLine) + $end;
+                            $toLine = mb_substr($toLine, 0, $start)
+                                . "\0"
+                                . mb_substr($toLine, $start, $realEnd - $start)
+                                . "\1"
+                                . mb_substr($toLine, $realEnd);
 							$a[$i1 + $i] = $fromLine;
 							$b[$j1 + $i] = $toLine;
 						}
@@ -149,13 +155,13 @@ class Diff_Renderer_Html_Array extends Diff_Renderer_Abstract
 	private function getChangeExtent($fromLine, $toLine)
 	{
 		$start = 0;
-		$limit = min(strlen($fromLine), strlen($toLine));
-		while($start < $limit && $fromLine{$start} == $toLine{$start}) {
+		$limit = min(mb_strlen($fromLine), mb_strlen($toLine));
+		while($start < $limit && mb_substr($fromLine, $start, 1) == mb_substr($toLine, $start, 1)) {
 			++$start;
 		}
 		$end = -1;
 		$limit = $limit - $start;
-		while(-$end <= $limit && substr($fromLine, $end, 1) == substr($toLine, $end, 1)) {
+		while(-$end <= $limit && mb_substr($fromLine, $end, 1) == mb_substr($toLine, $end, 1)) {
 			--$end;
 		}
 		return array(

--- a/lib/Diff/SequenceMatcher.php
+++ b/lib/Diff/SequenceMatcher.php
@@ -69,6 +69,10 @@ class Diff_SequenceMatcher
 
 	private $options = array();
 
+    private $matchingBlocks = null;
+    private $opCodes = null;
+    private $fullBCount = null;
+
 	private $defaultOptions = array(
 		'ignoreNewLines' => false,
 		'ignoreWhitespace' => false,
@@ -217,7 +221,7 @@ class Diff_SequenceMatcher
 	 */
 	private function isBJunk($b)
 	{
-		if(isset($this->juncDict[$b])) {
+		if(isset($this->junkDict[$b])) {
 			return true;
 		}
 
@@ -258,7 +262,7 @@ class Diff_SequenceMatcher
 		for($i = $alo; $i < $ahi; ++$i) {
 			$newJ2Len = array();
 			$jDict = $this->arrayGetDefault($this->b2j, $a[$i], $nothing);
-			foreach($jDict as $jKey => $j) {
+			foreach($jDict as $j) {
 				if($j < $blo) {
 					continue;
 				}
@@ -291,7 +295,7 @@ class Diff_SequenceMatcher
 		}
 
 		while($bestI > $alo && $bestJ > $blo && $this->isBJunk($b[$bestJ - 1]) &&
-			!$this->isLineDifferent($bestI - 1, $bestJ - 1)) {
+			!$this->linesAreDifferent($bestI - 1, $bestJ - 1)) {
 				--$bestI;
 				--$bestJ;
 				++$bestSize;


### PR DESCRIPTION
Previously the HTML renderer occasionally broke multibyte strings by inserting \0 and \1 between bytes of one character (see https://github.com/chrisboulton/php-diff/issues/14). This commit hopefully fixes the issue.

(whitespaces were replaced because of IDE automatic cleanups according to PSR-2 code style)