### PR TITLE
Use PHP_EOL constant to represent line endings

### DIFF
--- a/lib/Diff/Renderer/Text/Context.php
+++ b/lib/Diff/Renderer/Text/Context.php
@@ -72,17 +72,17 @@ class Diff_Renderer_Text_Context extends Diff_Renderer_Abstract
 			$j2 = $group[$lastItem][4];
 
 			if($i2 - $i1 >= 2) {
-				$diff .= '*** '.($group[0][1] + 1).','.$i2." ****\n";
+				$diff .= '*** '.($group[0][1] + 1).','.$i2." ****".PHP_EOL;
 			}
 			else {
 				$diff .= '*** '.$i2." ****\n";
 			}
 
 			if($j2 - $j1 >= 2) {
-				$separator = '--- '.($j1 + 1).','.$j2." ----\n";
+				$separator = '--- '.($j1 + 1).','.$j2." ----".PHP_EOL;
 			}
 			else {
-				$separator = '--- '.$j2." ----\n";
+				$separator = '--- '.$j2." ----".PHP_EOL;
 			}
 
 			$hasVisible = false;
@@ -99,7 +99,7 @@ class Diff_Renderer_Text_Context extends Diff_Renderer_Abstract
 					if($tag == 'insert') {
 						continue;
 					}
-					$diff .= $this->tagMap[$tag].' '.implode("\n".$this->tagMap[$tag].' ', $this->diff->GetA($i1, $i2))."\n";
+					$diff .= $this->tagMap[$tag].' '.implode(PHP_EOL.$this->tagMap[$tag].' ', $this->diff->GetA($i1, $i2)).PHP_EOL;
 				}
 			}
 
@@ -119,7 +119,7 @@ class Diff_Renderer_Text_Context extends Diff_Renderer_Abstract
 					if($tag == 'delete') {
 						continue;
 					}
-					$diff .= $this->tagMap[$tag].' '.implode("\n".$this->tagMap[$tag].' ', $this->diff->GetB($j1, $j2))."\n";
+					$diff .= $this->tagMap[$tag].' '.implode(PHP_EOL.$this->tagMap[$tag].' ', $this->diff->GetB($j1, $j2)).PHP_EOL;
 				}
 			}
 		}

--- a/lib/Diff/Renderer/Text/Unified.php
+++ b/lib/Diff/Renderer/Text/Unified.php
@@ -65,19 +65,19 @@ class Diff_Renderer_Text_Unified extends Diff_Renderer_Abstract
 				$i2 = -1;
 			}
 
-			$diff .= '@@ -'.($i1 + 1).','.($i2 - $i1).' +'.($j1 + 1).','.($j2 - $j1)." @@\n";
+			$diff .= '@@ -'.($i1 + 1).','.($i2 - $i1).' +'.($j1 + 1).','.($j2 - $j1)." @@".PHP_EOL;
 			foreach($group as $code) {
 				list($tag, $i1, $i2, $j1, $j2) = $code;
 				if($tag == 'equal') {
-					$diff .= ' '.implode("\n ", $this->diff->GetA($i1, $i2))."\n";
+					$diff .= ' '.implode(PHP_EOL." ", $this->diff->GetA($i1, $i2)).PHP_EOL;
 				}
 				else {
 					if($tag == 'replace' || $tag == 'delete') {
-						$diff .= '-'.implode("\n-", $this->diff->GetA($i1, $i2))."\n";
+						$diff .= '-'.implode(PHP_EOL."-", $this->diff->GetA($i1, $i2)).PHP_EOL;
 					}
 
 					if($tag == 'replace' || $tag == 'insert') {
-						$diff .= '+'.implode("\n+", $this->diff->GetB($j1, $j2))."\n";
+						$diff .= '+'.implode(PHP_EOL."+", $this->diff->GetB($j1, $j2)).PHP_EOL;
 					}
 				}
 			}


### PR DESCRIPTION
Using `\n` to represent line endings causes difficulties for users of Windows, and this is in turn affecting Phpspec.