### PR TITLE
Missing 'context' option pass to SequenceMatcher

### DIFF
--- a/lib/Diff.php
+++ b/lib/Diff.php
@@ -171,7 +171,7 @@ class Diff
 
 		require_once dirname(__FILE__).'/Diff/SequenceMatcher.php';
 		$sequenceMatcher = new Diff_SequenceMatcher($this->a, $this->b, null, $this->options);
-		$this->groupedCodes = $sequenceMatcher->getGroupedOpcodes();
+		$this->groupedCodes = $sequenceMatcher->getGroupedOpcodes($this->options['context']);
 		return $this->groupedCodes;
 	}
 }


### PR DESCRIPTION
It was missing and since many people use it (look Packagist) I think this kind of bug should be fixed ASAP.
