### PR TITLE
Don't let A & B be null when an empty array is passed

### DIFF
--- a/lib/Diff/SequenceMatcher.php
+++ b/lib/Diff/SequenceMatcher.php
@@ -131,7 +131,7 @@ class Diff_SequenceMatcher
 		if(!is_array($a)) {
 			$a = str_split($a);
 		}
-		if($a == $this->a) {
+		if($a === $this->a) {
 			return;
 		}
 
@@ -151,7 +151,7 @@ class Diff_SequenceMatcher
 		if(!is_array($b)) {
 			$b = str_split($b);
 		}
-		if($b == $this->b) {
+		if($b === $this->b) {
 			return;
 		}
 


### PR DESCRIPTION
When passing an empty array to `Diff` the `setSeq1` and `setSeq2` check on `null == []` will pass and `a` & `b` stay `null`.

This will cause an exception in `getMatchingBlocks`'s `count($this->a)` on PHP 8.

In PHP 7.4 the count could handle `null`, but not anymore.
https://www.php.net/manual/en/function.count.php